### PR TITLE
Improve shutdown reliability

### DIFF
--- a/src/vllm_service.py
+++ b/src/vllm_service.py
@@ -215,8 +215,16 @@ class VLLMServer:
 
         logger.info("[VLLMServer] Shutting down subprocess...")
         try:
-            requests.post(f"http://{self.host}:{self.port}/shutdown", timeout=5)
-        except Exception as e:
+            resp = requests.post(
+                f"http://{self.host}:{self.port}/shutdown",
+                timeout=5,
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "[VLLMServer] Shutdown request returned HTTP %s",
+                    resp.status_code,
+                )
+        except requests.RequestException as e:
             logger.warning("[VLLMServer] Shutdown request failed: %s", e)
 
         try:


### PR DESCRIPTION
## Summary
- add logger and clean shutdown endpoint logic
- remove stdout printing and schedule SIGINT using loop
- handle request errors explicitly when stopping subprocess

## Testing
- `pytest -q tests`
- `python -m py_compile src/vllm_server.py src/vllm_service.py src/vllm_client.py`

------
https://chatgpt.com/codex/tasks/task_e_684714bcceec832da5c9a55c39d8e660