### PR TITLE
Add async client support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,6 @@ dependencies = [
     "torch>=2.7.0",
     "tqdm>=4.67.1",
     "uvicorn>=0.34.3",
+    "httpx>=0.28.0",
     "vllm>=0.9.0.1",
 ]

--- a/src/vllm_service.py
+++ b/src/vllm_service.py
@@ -5,6 +5,7 @@ import time
 import subprocess
 import atexit
 import json
+import asyncio
 from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
 
@@ -386,16 +387,13 @@ class VLLMService:
         """Return True if at least one server subprocess is still alive."""
         return any(server.is_running() for server in self.servers)
 
-    def chat(
+    async def chat_async(
         self,
         conversations: List[List[Dict[str, str]]],
         sampling_params: SamplingParams | None = None,
         return_extra: bool = False,
     ) -> List[List[str]] | List[List[ResponseOutput]]:
-        """
-        Batched chat.
-        Returns a list of lists, each sub-list corresponds to number of outputs (n).
-        """
+        """Asynchronous batched chat."""
         if not self.clients:
             raise RuntimeError("Service not started. Call .start() first.")
         if sampling_params is None:
@@ -416,28 +414,33 @@ class VLLMService:
             batches.append(conversations[start : start + size])
             start += size
 
-        results: List[List] = []
-        with ThreadPoolExecutor(max_workers=num_servers) as ex:
-            futures = [ex.submit(client.chat, batch, sampling_params, return_extra) for client, batch in zip(self.clients, batches)]
-            for fut in futures:
-                results.append(fut.result())
+        tasks = [
+            client.chat_async(batch, sampling_params, return_extra)
+            for client, batch in zip(self.clients, batches)
+        ]
+        results = await asyncio.gather(*tasks)
 
         merged: List[List] = []
         for res in results:
             merged.extend(res)
         return merged
 
-    def generate(
+    def chat(
+        self,
+        conversations: List[List[Dict[str, str]]],
+        sampling_params: SamplingParams | None = None,
+        return_extra: bool = False,
+    ) -> List[List[str]] | List[List[ResponseOutput]]:
+        """Synchronous wrapper over :meth:`chat_async`."""
+        return asyncio.run(self.chat_async(conversations, sampling_params, return_extra))
+
+    async def generate_async(
         self,
         prompts: List[str],
         sampling_params: SamplingParams | None = None,
         return_extra: bool = False,
     ) -> List[List[str]] | List[List[ResponseOutput]]:
-        """
-        Batched generate.
-        Returns a list of lists, each sub-list corresponds to number of outputs (n).
-        Raises if not started.
-        """
+        """Asynchronous batched generate."""
         if not self.clients:
             raise RuntimeError("Service not started. Call .start() first.")
         if sampling_params is None:
@@ -458,16 +461,25 @@ class VLLMService:
             batches.append(prompts[start : start + size])
             start += size
 
-        results: List[List] = []
-        with ThreadPoolExecutor(max_workers=num_servers) as ex:
-            futures = [ex.submit(client.generate, batch, sampling_params, return_extra) for client, batch in zip(self.clients, batches)]
-            for fut in futures:
-                results.append(fut.result())
+        tasks = [
+            client.generate_async(batch, sampling_params, return_extra)
+            for client, batch in zip(self.clients, batches)
+        ]
+        results = await asyncio.gather(*tasks)
 
         merged: List[List] = []
         for res in results:
             merged.extend(res)
         return merged
+
+    def generate(
+        self,
+        prompts: List[str],
+        sampling_params: SamplingParams | None = None,
+        return_extra: bool = False,
+    ) -> List[List[str]] | List[List[ResponseOutput]]:
+        """Synchronous wrapper over :meth:`generate_async`."""
+        return asyncio.run(self.generate_async(prompts, sampling_params, return_extra))
 
     def shutdown(self) -> None:
         """Shut down all servers concurrently. Idempotent."""


### PR DESCRIPTION
## Summary
- replace `requests` with `httpx.AsyncClient`
- expose async `chat_async` and `generate_async` helpers in `VLLMClient`
- wrap sync `chat` and `generate` around the async versions
- update `VLLMService` to use `asyncio.gather`
- add httpx dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684721667a74832dad841fb08ab77491